### PR TITLE
Fix AETC list update on patient merge

### DIFF
--- a/app/controllers/dde_mahis/api/v1/dde_controller.rb
+++ b/app/controllers/dde_mahis/api/v1/dde_controller.rb
@@ -94,10 +94,13 @@ module DdeMahis
     end
 
     def remove_from_aetc_list
-      primary_person = Person.find_by(uuid: params[:primary][:patient_id])
+      primary_person = Person.includes(:names).find_by(uuid: params[:primary][:patient_id])
       AetcVisitList.where(uuid: params[:secondary].first[:patient_id])
                    .update_all(uuid: primary_person.uuid,
                                patient_id: primary_person.person_id,
+                               given_name: primary_person.names.first.given_name,
+                               family_name: primary_person.names.first.family_name,
+                               gender: primary_person.gender,
                                category: 'triage')
     end
   end

--- a/app/controllers/dde_mahis/api/v1/dde_controller.rb
+++ b/app/controllers/dde_mahis/api/v1/dde_controller.rb
@@ -1,6 +1,8 @@
 module DdeMahis
   class Api::V1::DdeController < ApplicationController
     # GET /dde/patients
+    after_action :remove_from_aetc_list, only: [:merge_patients]
+
     def find_patients_by_npid
       npid = params.require(:npid)
       render json: service.find_patients_by_npid(npid)
@@ -89,6 +91,15 @@ module DdeMahis
 
     def visit_type
       Program.find(params.require(:visit_type_id))
+    end
+
+    def remove_from_aetc_list
+      primary_person = Person.find_by_uuid(params[:primary].first[:patient_id])
+      AetcVisitList.where(uuid: params[:secondary]
+                   .first[:patient_id])
+                   .update_all(uuid: primary_person.uuid,
+                               patient_id: primary_person.person_id,
+                               category: 'triage')
     end
   end
 end

--- a/app/controllers/dde_mahis/api/v1/dde_controller.rb
+++ b/app/controllers/dde_mahis/api/v1/dde_controller.rb
@@ -94,9 +94,8 @@ module DdeMahis
     end
 
     def remove_from_aetc_list
-      primary_person = Person.find_by_uuid(params[:primary].first[:patient_id])
-      AetcVisitList.where(uuid: params[:secondary]
-                   .first[:patient_id])
+      primary_person = Person.find_by(uuid: params[:primary][:patient_id])
+      AetcVisitList.where(uuid: params[:secondary].first[:patient_id])
                    .update_all(uuid: primary_person.uuid,
                                patient_id: primary_person.person_id,
                                category: 'triage')


### PR DESCRIPTION
Implement a mechanism to update names and gender in the AETC list when merging patients, ensuring the list reflects the correct primary patient information.